### PR TITLE
feat: add support for unwinding versions using issue changelog

### DIFF
--- a/girastics/cli.py
+++ b/girastics/cli.py
@@ -40,6 +40,6 @@ def main(username, password, server, key, verbose):
                         format='%(levelname)s: %(message)s')
 
     jira = Jira(url=server, username=username, password=password)
-    print(jira.get_issue(key))
+    jira.get_issue(key)
 
     return 0


### PR DESCRIPTION
Unfortunately versions are handled with JIRA magic(tm) and have a
an implementation where the history item (Fix Version) is not
associated with the field (fixVersions). This change only adds
support for the Fix Version-field, using versions retrieved from
the associated project.